### PR TITLE
create errors.full_messages&collection_check_boxes

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,20 @@
 class GroupsController < ApplicationController
+  def new
+    @group = Group.new
+    @group.users << current_user
+  end
+
+  def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [] )
+  end
 end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,22 +1,27 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "/chat_groups", method: "post"}
-    %input{name: "utf8", type: "hidden", value: "✓"}/
-    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}/
-    .chat-group-form__field.clearfix
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+        %ul
+          - @group.errors.full_messages.each do |message|
+            %li= message
+    .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: 'chat-group-form__label'
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, class: 'chat_group_name chat-group-form__input', placeholder: "グループ名を入力してください"
     .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+        = f.label "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field.clearfix
+    .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/


### PR DESCRIPTION
# What
グループ作成時にユーザー名の横にチェックボックを入れた
エラーメッセージの実装
# Why
グループのメンバーを選択形式にして選べるようになる
メンバー未選択時などにエラーを通知するようになる